### PR TITLE
fix: potential fix for code scanning alert no. 4: workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -6,6 +6,8 @@ on:
       - "*"
     tags:
       - 'v*'
+permissions:
+  contents: read
 jobs:
   gofmt:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Layr-Labs/crypto-libs/security/code-scanning/4](https://github.com/Layr-Labs/crypto-libs/security/code-scanning/4)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will apply to all jobs in the workflow and will restrict the `GITHUB_TOKEN` to `contents: read`, which is sufficient for the tasks performed in this workflow. This change ensures that no unnecessary write permissions are granted, adhering to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
